### PR TITLE
feat(ntt): add zeta and zeta^2 values for bn256

### DIFF
--- a/ntt/parameters/alt_bn128.h
+++ b/ntt/parameters/alt_bn128.h
@@ -15,6 +15,12 @@ const fr_t group_gen = FR_T(vec256, 0x3057819e4fffffdbu, 0x307f6d866832bb01u, 0x
 // modular inverse of group_generator in r
 const fr_t group_gen_inverse = FR_T(vec256, 0xf41575289db6db6du, 0x07daec5e847b8b05u, 0xea0fce347eecc0e2u, 0x02017ed283b7fb4fu);
 
+// `zeta^3 = 1 mod r` where `zeta^2 != 1 mod r`
+const fr_t zeta = FR_T(vec256, 0x0363f29955fcd653u, 0x73e7950b5fc1e200u, 0xc5fce83e576d9d24u, 0x059c805da1c3a4d4u);
+
+// zeta^2
+const fr_t zeta_inverse = FR_T(vec256, 0x93e7cede4a0329b3u, 0x7d4fdca77a96c167u, 0x8be4ba08b19a750au, 0x1cbd5653a5661c25u);
+
 const int S = 28;
 
 const fr_t forward_roots_of_unity[S + 1] = {


### PR DESCRIPTION
**Motivation**
we need those values to match power distribution from sppark with halo2, in `halo2-axiom` `domain.rs` there is a function `coeff_to_extended` wich distributes powers on extended domain same as coset ntt,  in sppark coset ntt uses a bit different process, in `halo2-axiom` every three consecutive coefficient is pointwise multiplied to {1, zeta, zeta^2}. 
in sppark every a_i is multiplied to root_of_unity^i.  so to match the we need those values, zeta and zeta_inverse,  to properly implement `coeff_to_extended` and `extended_to_coeff`.  

**Changes Overview**
add zeta  and zeta^2 values for bn256