### PR TITLE
feat(stream_t): add stream constructor

### DIFF
--- a/util/gpu_t.cuh
+++ b/util/gpu_t.cuh
@@ -59,7 +59,7 @@ class stream_t {
 public:
     stream_t(int id) : gpu_id(id)
     {   cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking);   }
-    stream_t(int id, cudaStream_t _stream) : gpu_id(id), stream(_stream) {};
+    stream_t(int id, cudaStream_t _stream) : stream(_stream), gpu_id(id) {};
     ~stream_t()
     {   cudaStreamDestroy(stream);   }
     inline operator decltype(stream)() const    { return stream; }

--- a/util/gpu_t.cuh
+++ b/util/gpu_t.cuh
@@ -59,6 +59,7 @@ class stream_t {
 public:
     stream_t(int id) : gpu_id(id)
     {   cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking);   }
+    stream_t(int id, cudaStream_t _stream) : gpu_id(id), stream(_stream) {};
     ~stream_t()
     {   cudaStreamDestroy(stream);   }
     inline operator decltype(stream)() const    { return stream; }


### PR DESCRIPTION
**Motivation**
We need to be able to call sppark's ntt on a pre-existing stream, which requires constructing sppark's stream type with the existing stream.

**Changes**
Add a constructor to sppark's `stream_t` that takes a `cudaStream_t` as input rather than creating one internally.