### PR TITLE
fix(BB31): Added `#pragma once` in baby_bear.h file to prevent multiple inclusions

### DIFF
--- a/ntt/parameters/baby_bear.h
+++ b/ntt/parameters/baby_bear.h
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Values in Montgomery form
-
 #pragma once
+
+// Values in Montgomery form
 
 const fr_t group_gen = fr_t(0x2ffffffau);
 const fr_t group_gen_inverse = fr_t(0x2d555555u);

--- a/ntt/parameters/baby_bear.h
+++ b/ntt/parameters/baby_bear.h
@@ -4,6 +4,8 @@
 
 // Values in Montgomery form
 
+#pragma once
+
 const fr_t group_gen = fr_t(0x2ffffffau);
 const fr_t group_gen_inverse = fr_t(0x2d555555u);
 


### PR DESCRIPTION
**Motivation**
`baby_bear.h` file lacks protection for multiple inclusions and causing compilation errors.

**Changes Overview**
Added `#pragma once` in baby_bear.h