### PR TITLE
fix(ff): resolve constexpr codegen error with cuda 12.6

### DIFF
--- a/ff/alt_bn128.hpp
+++ b/ff/alt_bn128.hpp
@@ -10,41 +10,41 @@
 
 namespace device {
 #define TO_CUDA_T(limb64) (uint32_t)(limb64), (uint32_t)(limb64>>32)
-    static __device__ __constant__ __align__(16) const uint32_t ALT_BN128_P[8] = {
+    static __device__ __constant__ __align__(16) uint32_t ALT_BN128_P[8] = {
         TO_CUDA_T(0x3c208c16d87cfd47), TO_CUDA_T(0x97816a916871ca8d),
         TO_CUDA_T(0xb85045b68181585d), TO_CUDA_T(0x30644e72e131a029)
     };
-    static __device__ __constant__ __align__(16) const uint32_t ALT_BN128_RR[8] = { /* (1<<512)%P */
+    static __device__ __constant__ __align__(16) uint32_t ALT_BN128_RR[8] = { /* (1<<512)%P */
         TO_CUDA_T(0xf32cfc5b538afa89), TO_CUDA_T(0xb5e71911d44501fb),
         TO_CUDA_T(0x47ab1eff0a417ff6), TO_CUDA_T(0x06d89f71cab8351f),
     };
-    static __device__ __constant__ __align__(16) const uint32_t ALT_BN128_one[8] = { /* (1<<256)%P */
+    static __device__ __constant__ __align__(16) uint32_t ALT_BN128_one[8] = { /* (1<<256)%P */
         TO_CUDA_T(0xd35d438dc58f0d9d), TO_CUDA_T(0x0a78eb28f5c70b3d),
         TO_CUDA_T(0x666ea36f7879462c), TO_CUDA_T(0x0e0a77c19a07df2f)
     };
-    static __device__ __constant__ __align__(16) const uint32_t ALT_BN128_Px4[8] = { /* left-aligned value of the modulus */
+    static __device__ __constant__ __align__(16) uint32_t ALT_BN128_Px4[8] = { /* left-aligned value of the modulus */
         TO_CUDA_T(0xf082305b61f3f51c), TO_CUDA_T(0x5e05aa45a1c72a34),
         TO_CUDA_T(0xe14116da06056176), TO_CUDA_T(0xc19139cb84c680a6)
     };
-    static __device__ __constant__ const uint32_t ALT_BN128_M0 = 0xe4866389;
+    static __device__ __constant__ uint32_t ALT_BN128_M0 = 0xe4866389;
 
-    static __device__ __constant__ __align__(16) const uint32_t ALT_BN128_r[8] = {
+    static __device__ __constant__ __align__(16) uint32_t ALT_BN128_r[8] = {
         TO_CUDA_T(0x43e1f593f0000001), TO_CUDA_T(0x2833e84879b97091),
         TO_CUDA_T(0xb85045b68181585d), TO_CUDA_T(0x30644e72e131a029)
     };
-    static __device__ __constant__ __align__(16) const uint32_t ALT_BN128_rRR[8] = { /* (1<<512)%P */
+    static __device__ __constant__ __align__(16) uint32_t ALT_BN128_rRR[8] = { /* (1<<512)%P */
         TO_CUDA_T(0x1bb8e645ae216da7), TO_CUDA_T(0x53fe3ab1e35c59e3),
         TO_CUDA_T(0x8c49833d53bb8085), TO_CUDA_T(0x0216d0b17f4e44a5)
     };
-    static __device__ __constant__ __align__(16) const uint32_t ALT_BN128_rone[8] = { /* (1<<256)%P */
+    static __device__ __constant__ __align__(16) uint32_t ALT_BN128_rone[8] = { /* (1<<256)%P */
         TO_CUDA_T(0xac96341c4ffffffb), TO_CUDA_T(0x36fc76959f60cd29),
         TO_CUDA_T(0x666ea36f7879462e), TO_CUDA_T(0x0e0a77c19a07df2f)
     };
-    static __device__ __constant__ __align__(16) const uint32_t ALT_BN128_rx4[8] = { /* left-aligned value of the modulus */
+    static __device__ __constant__ __align__(16) uint32_t ALT_BN128_rx4[8] = { /* left-aligned value of the modulus */
         TO_CUDA_T(0x0f87d64fc0000004), TO_CUDA_T(0xa0cfa121e6e5c245),
         TO_CUDA_T(0xe14116da06056174), TO_CUDA_T(0xc19139cb84c680a6)
     };
-    static __device__ __constant__ const uint32_t ALT_BN128_m0 = 0xefffffff;
+    static __device__ __constant__ uint32_t ALT_BN128_m0 = 0xefffffff;
 }
 # ifdef __CUDA_ARCH__   // device-side field types
 # include "mont_t.cuh"

--- a/ff/bls12-377.hpp
+++ b/ff/bls12-377.hpp
@@ -10,41 +10,41 @@
 
 namespace device {
 #define TO_CUDA_T(limb64) (uint32_t)(limb64), (uint32_t)(limb64>>32)
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_377_P[12] = {
+    static __device__ __constant__ __align__(16) uint32_t BLS12_377_P[12] = {
         TO_CUDA_T(0x8508c00000000001), TO_CUDA_T(0x170b5d4430000000),
         TO_CUDA_T(0x1ef3622fba094800), TO_CUDA_T(0x1a22d9f300f5138f),
         TO_CUDA_T(0xc63b05c06ca1493b), TO_CUDA_T(0x01ae3a4617c510ea)
     };
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_377_RR[12] = { /* (1<<768)%P */
+    static __device__ __constant__ __align__(16) uint32_t BLS12_377_RR[12] = { /* (1<<768)%P */
         TO_CUDA_T(0xb786686c9400cd22), TO_CUDA_T(0x0329fcaab00431b1),
         TO_CUDA_T(0x22a5f11162d6b46d), TO_CUDA_T(0xbfdf7d03827dc3ac),
         TO_CUDA_T(0x837e92f041790bf9), TO_CUDA_T(0x006dfccb1e914b88)
     };
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_377_one[12] = { /* (1<<384)%P */
+    static __device__ __constant__ __align__(16) uint32_t BLS12_377_one[12] = { /* (1<<384)%P */
         TO_CUDA_T(0x02cdffffffffff68), TO_CUDA_T(0x51409f837fffffb1),
         TO_CUDA_T(0x9f7db3a98a7d3ff2), TO_CUDA_T(0x7b4e97b76e7c6305),
         TO_CUDA_T(0x4cf495bf803c84e8), TO_CUDA_T(0x008d6661e2fdf49a)
     };
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_381_Px128[12] = { /* left-aligned value of the modulus */
+    static __device__ __constant__ __align__(16) uint32_t BLS12_381_Px128[12] = { /* left-aligned value of the modulus */
         TO_CUDA_T(0x8460000000000080), TO_CUDA_T(0x85aea21800000042),
         TO_CUDA_T(0x79b117dd04a4000b), TO_CUDA_T(0x116cf9807a89c78f),
         TO_CUDA_T(0x1d82e03650a49d8d), TO_CUDA_T(0xd71d230be2887563)
     };
     static __device__ __constant__ /*const*/ uint32_t BLS12_377_M0 = 0xffffffff;
 
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_377_r[8] = {
+    static __device__ __constant__ __align__(16) uint32_t BLS12_377_r[8] = {
         TO_CUDA_T(0x0a11800000000001), TO_CUDA_T(0x59aa76fed0000001),
         TO_CUDA_T(0x60b44d1e5c37b001), TO_CUDA_T(0x12ab655e9a2ca556)
     };
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_377_rRR[8] = { /* (1<<512)%P */
+    static __device__ __constant__ __align__(16) uint32_t BLS12_377_rRR[8] = { /* (1<<512)%P */
         TO_CUDA_T(0x25d577bab861857b), TO_CUDA_T(0xcc2c27b58860591f),
         TO_CUDA_T(0xa7cc008fe5dc8593), TO_CUDA_T(0x011fdae7eff1c939)
     };
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_377_rone[8] = { /* (1<<256)%P */
+    static __device__ __constant__ __align__(16) uint32_t BLS12_377_rone[8] = { /* (1<<256)%P */
         TO_CUDA_T(0x7d1c7ffffffffff3), TO_CUDA_T(0x7257f50f6ffffff2),
         TO_CUDA_T(0x16d81575512c0fee), TO_CUDA_T(0x0d4bda322bbb9a9d)
     };
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_377_rx8[8] = { /* left-aligned value of the modulus */
+    static __device__ __constant__ __align__(16) uint32_t BLS12_377_rx8[8] = { /* left-aligned value of the modulus */
         TO_CUDA_T(0x508c000000000008), TO_CUDA_T(0xcd53b7f680000008),
         TO_CUDA_T(0x05a268f2e1bd800a), TO_CUDA_T(0x955b2af4d1652ab3)
     };

--- a/ff/bls12-381.hpp
+++ b/ff/bls12-381.hpp
@@ -10,41 +10,41 @@
 
 namespace device {
 #define TO_CUDA_T(limb64) (uint32_t)(limb64), (uint32_t)(limb64>>32)
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_381_P[12] = {
+    static __device__ __constant__ __align__(16) uint32_t BLS12_381_P[12] = {
         TO_CUDA_T(0xb9feffffffffaaab), TO_CUDA_T(0x1eabfffeb153ffff),
         TO_CUDA_T(0x6730d2a0f6b0f624), TO_CUDA_T(0x64774b84f38512bf),
         TO_CUDA_T(0x4b1ba7b6434bacd7), TO_CUDA_T(0x1a0111ea397fe69a)
     };
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_381_RR[12] = { /* (1<<768)%P */
+    static __device__ __constant__ __align__(16) uint32_t BLS12_381_RR[12] = { /* (1<<768)%P */
         TO_CUDA_T(0xf4df1f341c341746), TO_CUDA_T(0x0a76e6a609d104f1),
         TO_CUDA_T(0x8de5476c4c95b6d5), TO_CUDA_T(0x67eb88a9939d83c0),
         TO_CUDA_T(0x9a793e85b519952d), TO_CUDA_T(0x11988fe592cae3aa)
     };
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_381_one[12] = { /* (1<<384)%P */
+    static __device__ __constant__ __align__(16) uint32_t BLS12_381_one[12] = { /* (1<<384)%P */
         TO_CUDA_T(0x760900000002fffd), TO_CUDA_T(0xebf4000bc40c0002),
         TO_CUDA_T(0x5f48985753c758ba), TO_CUDA_T(0x77ce585370525745),
         TO_CUDA_T(0x5c071a97a256ec6d), TO_CUDA_T(0x15f65ec3fa80e493)
     };
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_381_Px8[12] = { /* left-aligned value of the modulus */
+    static __device__ __constant__ __align__(16) uint32_t BLS12_381_Px8[12] = { /* left-aligned value of the modulus */
         TO_CUDA_T(0xcff7fffffffd5558), TO_CUDA_T(0xf55ffff58a9ffffd),
         TO_CUDA_T(0x39869507b587b120), TO_CUDA_T(0x23ba5c279c2895fb),
         TO_CUDA_T(0x58dd3db21a5d66bb), TO_CUDA_T(0xd0088f51cbff34d2)
     };
-    static __device__ __constant__ const uint32_t BLS12_381_M0 = 0xfffcfffd;
+    static __device__ __constant__ uint32_t BLS12_381_M0 = 0xfffcfffd;
 
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_381_r[8] = {
+    static __device__ __constant__ __align__(16) uint32_t BLS12_381_r[8] = {
         TO_CUDA_T(0xffffffff00000001), TO_CUDA_T(0x53bda402fffe5bfe),
         TO_CUDA_T(0x3339d80809a1d805), TO_CUDA_T(0x73eda753299d7d48)
     };
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_381_rRR[8] = { /* (1<<512)%P */
+    static __device__ __constant__ __align__(16) uint32_t BLS12_381_rRR[8] = { /* (1<<512)%P */
         TO_CUDA_T(0xc999e990f3f29c6d), TO_CUDA_T(0x2b6cedcb87925c23),
         TO_CUDA_T(0x05d314967254398f), TO_CUDA_T(0x0748d9d99f59ff11)
     };
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_381_rone[8] = { /* (1<<256)%P */
+    static __device__ __constant__ __align__(16) uint32_t BLS12_381_rone[8] = { /* (1<<256)%P */
         TO_CUDA_T(0x00000001fffffffe), TO_CUDA_T(0x5884b7fa00034802),
         TO_CUDA_T(0x998c4fefecbc4ff5), TO_CUDA_T(0x1824b159acc5056f)
     };
-    static __device__ __constant__ __align__(16) const uint32_t BLS12_381_rx2[8] = { /* left-aligned value of the modulus */
+    static __device__ __constant__ __align__(16) uint32_t BLS12_381_rx2[8] = { /* left-aligned value of the modulus */
         TO_CUDA_T(0xfffffffe00000002), TO_CUDA_T(0xa77b4805fffcb7fd),
         TO_CUDA_T(0x6673b0101343b00a), TO_CUDA_T(0xe7db4ea6533afa90),
     };

--- a/ff/pasta.hpp
+++ b/ff/pasta.hpp
@@ -9,36 +9,36 @@
 #include <cstdint>
 
 namespace device {
-    static __device__ __constant__ __align__(16) const uint32_t Vesta_P[8] = {
+    static __device__ __constant__ __align__(16) uint32_t Vesta_P[8] = {
         0x00000001, 0x8c46eb21, 0x0994a8dd, 0x224698fc,
         0x00000000, 0x00000000, 0x00000000, 0x40000000
     };
-    static __device__ __constant__ __align__(16) const uint32_t Vesta_RR[8] = { /* (1<<512)%P */
+    static __device__ __constant__ __align__(16) uint32_t Vesta_RR[8] = { /* (1<<512)%P */
         0x0000000f, 0xfc9678ff, 0x891a16e3, 0x67bb433d,
         0x04ccf590, 0x7fae2310, 0x7ccfdaa9, 0x096d41af
     };
-    static __device__ __constant__ __align__(16) const uint32_t Vesta_one[8] = { /* (1<<256)%P */
+    static __device__ __constant__ __align__(16) uint32_t Vesta_one[8] = { /* (1<<256)%P */
         0xfffffffd, 0x5b2b3e9c, 0xe3420567, 0x992c350b,
         0xffffffff, 0xffffffff, 0xffffffff, 0x3fffffff
     };
-    static __device__ __constant__ __align__(16) const uint32_t Vesta_Px2[8] = { /* left-aligned modulus */
+    static __device__ __constant__ __align__(16) uint32_t Vesta_Px2[8] = { /* left-aligned modulus */
         0x00000002, 0x188dd642, 0x132951bb, 0x448d31f8,
         0x00000000, 0x00000000, 0x00000000, 0x80000000
     };
 
-    static __device__ __constant__ __align__(16) const uint32_t Pallas_P[8] = {
+    static __device__ __constant__ __align__(16) uint32_t Pallas_P[8] = {
         0x00000001, 0x992d30ed, 0x094cf91b, 0x224698fc,
         0x00000000, 0x00000000, 0x00000000, 0x40000000
     };
-    static __device__ __constant__ __align__(16) const uint32_t Pallas_RR[8] = { /* (1<<512)%P */
+    static __device__ __constant__ __align__(16) uint32_t Pallas_RR[8] = { /* (1<<512)%P */
         0x0000000f, 0x8c78ecb3, 0x8b0de0e7, 0xd7d30dbd,
         0xc3c95d18, 0x7797a99b, 0x7b9cb714, 0x096d41af
     };
-    static __device__ __constant__ __align__(16) const uint32_t Pallas_one[8] = { /* (1<<256)%P */
+    static __device__ __constant__ __align__(16) uint32_t Pallas_one[8] = { /* (1<<256)%P */
         0xfffffffd, 0x34786d38, 0xe41914ad, 0x992c350b,
         0xffffffff, 0xffffffff, 0xffffffff, 0x3fffffff
     };
-    static __device__ __constant__ __align__(16) const uint32_t Pallas_Px2[8] = { /* left-aligned modulus */
+    static __device__ __constant__ __align__(16) uint32_t Pallas_Px2[8] = { /* left-aligned modulus */
         0x00000002, 0x325a61da, 0x1299f237, 0x448d31f8,
         0x00000000, 0x00000000, 0x00000000, 0x80000000
     };


### PR DESCRIPTION
**Motivation**
After CUDA update to 12.6, calling the mont_t is_one() function produces the following: `Internal Compiler Error (codegen): "constant expressions are not supported!"`

**Changes**
I've traced the error back to the combined use of `__constant__ const` in the definitions of field constants; removing the `const` resolves the problem.